### PR TITLE
Se 8842 restrict push notifications by app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .yardoc
 .ruby-version
 .env
+.idea/
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/appboy/api.rb
+++ b/lib/appboy/api.rb
@@ -13,18 +13,5 @@ module Appboy
     include Appboy::Endpoints::ScheduleMessages
     include Appboy::Endpoints::EmailStatus
 
-    def export_users(**payload)
-      Appboy::REST::ExportUsers.new.perform(app_group_id, payload)
-    end
-
-    def list_segments
-      Appboy::REST::ListSegments.new.perform(app_group_id)
-    end
-
-    attr_reader :app_group_id
-
-    def initialize(app_group_id)
-      @app_group_id = app_group_id
-    end
   end
 end

--- a/lib/appboy/endpoints/email_status.rb
+++ b/lib/appboy/endpoints/email_status.rb
@@ -2,7 +2,7 @@ module Appboy
   module Endpoints
     module EmailStatus
       def email_status(**payload)
-        email_status_service.new(app_group_id, payload).perform
+        email_status_service.new(payload).perform
       end
 
       def email_status_service

--- a/lib/appboy/endpoints/schedule_messages.rb
+++ b/lib/appboy/endpoints/schedule_messages.rb
@@ -2,7 +2,7 @@ module Appboy
   module Endpoints
     module ScheduleMessages
       def schedule_messages(**payload)
-        schedule_messages_service.new(app_group_id, payload).perform
+        schedule_messages_service.new(payload).perform
       end
 
       private

--- a/lib/appboy/endpoints/send_messages.rb
+++ b/lib/appboy/endpoints/send_messages.rb
@@ -2,7 +2,7 @@ module Appboy
   module Endpoints
     module SendMessages
       def send_messages(**payload)
-        send_messages_service.new(app_group_id, payload).perform
+        send_messages_service.new(payload).perform
       end
 
       private

--- a/lib/appboy/endpoints/track_users.rb
+++ b/lib/appboy/endpoints/track_users.rb
@@ -4,7 +4,7 @@ module Appboy
       attr_writer :track_users_service
 
       def track_users(**payload)
-        track_users_service.perform(app_group_id, payload)
+        track_users_service.perform(payload)
       end
 
       def track_purchase(payload)

--- a/lib/appboy/http.rb
+++ b/lib/appboy/http.rb
@@ -5,12 +5,12 @@ module Appboy
   class HTTP
     def post(path, payload)
       req = connection.post path, payload
-      {body: req.body, headers: req.headers }
+      {body: req.body, headers: req.headers, status: req.status }
     end
 
     def get(path, query)
       req = connection.get path, query
-      {body: req.body, headers: req.headers }
+      {body: req.body, headers: req.headers,  status: req.status }
     end
 
     def connection

--- a/lib/appboy/http.rb
+++ b/lib/appboy/http.rb
@@ -4,13 +4,13 @@ require 'faraday_middleware'
 module Appboy
   class HTTP
     def post(path, payload)
-      connection.post path do |request|
-        request.body = payload
-      end
+      req = connection.post path, payload
+      {body: req.body, headers: req.headers }
     end
 
     def get(path, query)
-      connection.get path, query
+      req = connection.get path, query
+      {body: req.body, headers: req.headers }
     end
 
     def connection

--- a/lib/appboy/rest/base.rb
+++ b/lib/appboy/rest/base.rb
@@ -4,7 +4,6 @@ module Appboy
   module REST
     class Base
       attr_writer :http
-
       private
 
       def http

--- a/lib/appboy/rest/schedule_messages.rb
+++ b/lib/appboy/rest/schedule_messages.rb
@@ -3,7 +3,7 @@ module Appboy
     class ScheduleMessages < Base
       attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids, :campaign_id
 
-      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil,  local_timezone: false)
+      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil,  local_timezone: true)
         @app_group_id = app_group_id
         @send_at = send_at
         @messages = messages

--- a/lib/appboy/rest/schedule_messages.rb
+++ b/lib/appboy/rest/schedule_messages.rb
@@ -1,15 +1,16 @@
 module Appboy
   module REST
     class ScheduleMessages < Base
-      attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids
+      attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids, :campaign_id
 
-      def initialize(app_group_id, send_at:, messages: [], segment_id: nil, external_user_ids: [], local_timezone: false)
+      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil,  local_timezone: false)
         @app_group_id = app_group_id
         @send_at = send_at
         @messages = messages
         @segment_id = segment_id
         @external_user_ids = external_user_ids
         @local_timezone = local_timezone
+        @campaign_id = campaign_id
       end
 
       def perform
@@ -23,6 +24,7 @@ module Appboy
         else
           payload.merge!(segment_id: segment_id)
         end
+        payload.merge!(campaign_id: campaign_id) unless campaign_id.nil?
         http.post '/messages/schedule/create', payload
       end
     end

--- a/lib/appboy/rest/schedule_messages.rb
+++ b/lib/appboy/rest/schedule_messages.rb
@@ -3,7 +3,7 @@ module Appboy
     class ScheduleMessages < Base
       attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids, :campaign_id
 
-      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil,  local_timezone: true)
+      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], local_timezone: false, campaign_id: nil, segment_id: nil,  logger: nil)
         @app_group_id = app_group_id
         @send_at = send_at
         @messages = messages
@@ -11,6 +11,8 @@ module Appboy
         @external_user_ids = external_user_ids
         @local_timezone = local_timezone
         @campaign_id = campaign_id
+        @schedule_uri = '/messages/schedule/create'
+        @logger = logger
       end
 
       def perform
@@ -25,7 +27,8 @@ module Appboy
           payload.merge!(segment_id: segment_id)
         end
         payload.merge!(campaign_id: campaign_id) unless campaign_id.nil?
-        http.post '/messages/schedule/create', payload
+        @logger.info("#{self.class.name}") { "http.post: #{@schedule_uri} payload: #{payload.to_s}"} unless @logger.nil?
+        http.post @schedule_uri, payload
       end
     end
   end

--- a/lib/appboy/rest/schedule_messages.rb
+++ b/lib/appboy/rest/schedule_messages.rb
@@ -1,9 +1,10 @@
 module Appboy
   module REST
     class ScheduleMessages < Base
+
       attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids, :campaign_id
 
-      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], local_timezone: false, campaign_id: nil, segment_id: nil,  logger: nil)
+      def initialize(app_group_id, send_at:, messages: [], external_user_ids: [], local_timezone: false, campaign_id: nil, segment_id: nil, logger: nil)
         @app_group_id = app_group_id
         @send_at = send_at
         @messages = messages
@@ -28,7 +29,9 @@ module Appboy
         end
         payload.merge!(campaign_id: campaign_id) unless campaign_id.nil?
         @logger.info("#{self.class.name}") { "http.post: #{@schedule_uri} payload: #{payload.to_s}"} unless @logger.nil?
-        http.post @schedule_uri, payload
+        result = http.post @schedule_uri, payload
+        @logger.info("#{self.class.name}") { "http.result: #{result.to_s}"} unless @logger.nil?
+        result
       end
     end
   end

--- a/lib/appboy/rest/schedule_messages.rb
+++ b/lib/appboy/rest/schedule_messages.rb
@@ -1,24 +1,29 @@
 module Appboy
   module REST
     class ScheduleMessages < Base
-      attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone
+      attr_reader :app_group_id, :send_at, :messages, :segment_id, :local_timezone, :external_user_ids
 
-      def initialize(app_group_id, send_at:, messages: [], segment_id: nil, local_timezone: false)
+      def initialize(app_group_id, send_at:, messages: [], segment_id: nil, external_user_ids: [], local_timezone: false)
         @app_group_id = app_group_id
         @send_at = send_at
         @messages = messages
         @segment_id = segment_id
+        @external_user_ids = external_user_ids
         @local_timezone = local_timezone
       end
 
       def perform
-        http.post '/messages/schedule', {
+        payload = {
           app_group_id:      app_group_id,
-          segment_ids:               [segment_id],
-          send_at:                   send_at,
-          deliver_in_local_timezone: local_timezone,
+          schedule: {time: send_at, in_local_time: local_timezone},
           messages:                  messages
         }
+        if external_user_ids.size > 0
+          payload.merge!(external_user_ids: external_user_ids)
+        else
+          payload.merge!(segment_id: segment_id)
+        end
+        http.post '/messages/schedule/create', payload
       end
     end
   end

--- a/lib/appboy/rest/send_messages.rb
+++ b/lib/appboy/rest/send_messages.rb
@@ -3,22 +3,26 @@ module Appboy
     class SendMessages < Base
       attr_reader :app_group_id, :messages, :external_user_ids, :segment_id, :campaign_id
 
-      def initialize(app_group_id, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil)
+      def initialize(app_group_id, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil, logger: nil)
         @app_group_id = app_group_id
         @messages = messages
         @external_user_ids = external_user_ids
         @campaign_id = campaign_id
         @segment_id = segment_id
+        @send_uri = '/messages/send'
+        @logger = logger
       end
 
       def perform
-        http.post '/messages/send', {
-          app_group_id:      app_group_id,
-          messages:          messages,
-          external_user_ids: external_user_ids,
-          campaign_id: campaign_id,
-          segment_ids:       [segment_id].compact
+        payload = {
+            app_group_id:      app_group_id,
+            messages:          messages,
+            external_user_ids: external_user_ids,
+            campaign_id: campaign_id,
+            segment_ids:       [segment_id].compact
         }
+        @logger.info("#{self.class.name}") { "http.post: #{@send_uri} payload: #{payload.to_s}"} unless @logger.nil?
+        http.post @send_uri, payload
       end
     end
   end

--- a/lib/appboy/rest/send_messages.rb
+++ b/lib/appboy/rest/send_messages.rb
@@ -1,6 +1,7 @@
 module Appboy
   module REST
     class SendMessages < Base
+
       attr_reader :app_group_id, :messages, :external_user_ids, :segment_id, :campaign_id
 
       def initialize(app_group_id, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil, logger: nil)
@@ -22,7 +23,9 @@ module Appboy
             segment_ids:       [segment_id].compact
         }
         @logger.info("#{self.class.name}") { "http.post: #{@send_uri} payload: #{payload.to_s}"} unless @logger.nil?
-        http.post @send_uri, payload
+        result = http.post @send_uri, payload
+        @logger.info("#{self.class.name}") { "http.result: #{result.to_s}"} unless @logger.nil?
+        result
       end
     end
   end

--- a/lib/appboy/rest/send_messages.rb
+++ b/lib/appboy/rest/send_messages.rb
@@ -1,12 +1,13 @@
 module Appboy
   module REST
     class SendMessages < Base
-      attr_reader :app_group_id, :messages, :external_user_ids, :segment_id
+      attr_reader :app_group_id, :messages, :external_user_ids, :segment_id, :campaign_id
 
-      def initialize(app_group_id, messages: [], external_user_ids: [], segment_id: nil)
+      def initialize(app_group_id, messages: [], external_user_ids: [], campaign_id: nil, segment_id: nil)
         @app_group_id = app_group_id
         @messages = messages
         @external_user_ids = external_user_ids
+        @campaign_id = campaign_id
         @segment_id = segment_id
       end
 
@@ -15,6 +16,7 @@ module Appboy
           app_group_id:      app_group_id,
           messages:          messages,
           external_user_ids: external_user_ids,
+          campaign_id: campaign_id,
           segment_ids:       [segment_id].compact
         }
       end

--- a/spec/appboy/rest/schedule_messages_spec.rb
+++ b/spec/appboy/rest/schedule_messages_spec.rb
@@ -4,15 +4,14 @@ describe Appboy::REST::ScheduleMessages do
   let(:http) { double(:http) }
 
   let(:payload) {{
+    app_group_id: :app_group_id,
     send_at: :send_at,
     segment_id: :segment_id,
     local_timezone: :local_timezone,
     messages: :messages
   }}
 
-  let(:app_group_id) { :app_group_id }
-
-  subject { described_class.new(app_group_id, payload) }
+  subject { described_class.new(payload) }
 
   before { subject.http = http }
 
@@ -24,7 +23,7 @@ describe Appboy::REST::ScheduleMessages do
 
   def expect_schedule_messages_http_call
     expect(http).to receive(:post).with '/messages/schedule', {
-      app_group_id: app_group_id,
+      app_group_id: :app_group_id,
       segment_ids: [:segment_id],
       send_at: :send_at,
       deliver_in_local_timezone: :local_timezone,

--- a/spec/appboy/rest/send_messages_spec.rb
+++ b/spec/appboy/rest/send_messages_spec.rb
@@ -4,12 +4,11 @@ describe Appboy::REST::SendMessages do
   let(:http) { double(:http) }
 
   let(:payload) {{
+    app_group_id: :app_group_id,
     messages: :messages,
     external_user_ids: :external_user_ids,
     segment_id: :segment_id
   }}
-
-  let(:app_group_id) { :app_group_id }
 
   subject { described_class.new(app_group_id,
     messages: :messages,


### PR DESCRIPTION
this change to appboy is to make the app_group_id part of the parameters hash. 

originally the app_group_id was a standalone param to the `initialize` method. 

we could leave the appboy api unchanged and create separate api clients from the se app, but I failed to see the benefit of giving the app_group_id param the special treatment it was getting. bundling it as part of the params hash seems more straightforward as we can just encapsulate all the information the notification needs to send itself, and this in turn keeps the push.rb code simpler.