### PR TITLE
Use env to select api rest base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Or install it yourself as:
 api = Appboy::API.new('<app-group-id>')
 ```
 
+By default Appboy will be using 'https://api.appboy.com' as the default REST API base url, but you can override this base url by setting the env variable `APPBOY_REST_BASE_URL`. E.G.
+
+```
+APPBOY_REST_BASE_URL="https://rest.iad-01.braze.com" 
+```
+
 ### Track User Attributes
 
 See: [User Attributes Object Specification](https://documentation.appboy.com/REST_APIs/User_Data#user-attribute-object)

--- a/lib/appboy/http.rb
+++ b/lib/appboy/http.rb
@@ -14,13 +14,19 @@ module Appboy
     end
 
     def connection
-      @connection ||= Faraday.new(url: 'https://api.appboy.com') do |connection|
+      @connection ||= Faraday.new(url: api_host) do |connection|
         connection.request :json
 
         connection.response :logger if ENV['APPBOY_DEBUG']
 
         connection.adapter Faraday.default_adapter
       end
+    end
+
+    private
+
+    def api_host
+      @api_host ||= ENV.fetch('APPBOY_REST_BASE_URL', 'https://api.appboy.com')
     end
   end
 end

--- a/spec/appboy/http_spec.rb
+++ b/spec/appboy/http_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'appboy/http'
+
+describe Appboy::HTTP do
+  describe '#connection' do
+    it 'sets the default url prefix' do
+      expect(subject.connection.url_prefix.to_s).to eql "https://api.appboy.com/"
+    end
+
+    context 'when the env contains `APPBOY_REST_BASE_URL` env variable' do
+      before { ENV['APPBOY_REST_BASE_URL'] = "https://new.braze.com" }
+      after  { ENV.delete('APPBOY_REST_BASE_URL') }
+
+      it 'initializes the connection with it' do
+        expect(subject.connection.url_prefix.to_s).to eql "https://new.braze.com/"
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Description

As mentioned on the [Braze documentation](https://www.braze.com/documentation/REST_API/#endpoints), the base url of the REST Api might change, which means that applications using this library should have a way to change the default API endpoint. 

The simplest way to override that value is by using the ENV, which is what I've done in this PR. Also, I've added a couple of tests for it, but note that the `FactoryGirl.lint` is raising an exception so the test suit does not pass.